### PR TITLE
[BG]: [GROWTH-1025] Add CDN Url handling to SIH

### DIFF
--- a/.github/workflows/deploy_function_code_to_staging.yml
+++ b/.github/workflows/deploy_function_code_to_staging.yml
@@ -1,4 +1,4 @@
-name: Deploy Function Code to Prod
+name: Deploy Function Code to Staging
 
 on:
   push:

--- a/source/image-handler/index.ts
+++ b/source/image-handler/index.ts
@@ -147,13 +147,12 @@ function getResponseHeaders(isError: boolean = false, isAlb: boolean = false): H
  */
 function transformCdnUrls(url: string): string {
   // Regular expression to detect the second type of URL and capture the dynamic parts
-  const regex = /\/fit-in\/(\d+x\d+)\/filters:quality\((\d+)\)\/cdn-cgi\/image\/fit=contain,width=\d+,height=\d+/;
+  const regex = /\/cdn-cgi\/image\/fit=contain,width=\d+,height=\d+/;
 
   // Check if the URL matches the pattern
   if (regex.test(url)) {
-    // Replace the matched part of the URL with the corresponding part from the first type of URL
-    // and reinsert the captured dynamic parts
-    return url.replace(regex, (_match, p1, p2) => `/fit-in/${p1}/filters:quality(${p2})`);
+   // Replace the matched part of the URL with an empty string, effectively removing it
+   return url.replace(regex, '');
   }
 
   // If the URL does not match the pattern, return it unchanged

--- a/source/image-handler/index.ts
+++ b/source/image-handler/index.ts
@@ -24,6 +24,7 @@ const secretProvider = new SecretProvider(secretsManagerClient);
  * @returns Processed request response.
  */
 export async function handler(event: ImageHandlerEvent): Promise<ImageHandlerExecutionResult> {
+  event.path = transformCdnUrls(event.path);
   console.info("Received event:", JSON.stringify(event, null, 2));
 
   const imageRequest = new ImageRequest(s3Client, secretProvider);
@@ -137,4 +138,24 @@ function getResponseHeaders(isError: boolean = false, isAlb: boolean = false): H
   }
 
   return headers;
+}
+
+/**
+ * Transorm CDN URLs to the format expected by the image handler.
+ * @param url
+ * @returns Transformed URL.
+ */
+function transformCdnUrls(url: string): string {
+  // Regular expression to detect the second type of URL and capture the dynamic parts
+  const regex = /\/fit-in\/(\d+x\d+)\/filters:quality\((\d+)\)\/cdn-cgi\/image\/fit=contain,width=\d+,height=\d+/;
+
+  // Check if the URL matches the pattern
+  if (regex.test(url)) {
+    // Replace the matched part of the URL with the corresponding part from the first type of URL
+    // and reinsert the captured dynamic parts
+    return url.replace(regex, (_match, p1, p2) => `/fit-in/${p1}/filters:quality(${p2})`);
+  }
+
+  // If the URL does not match the pattern, return it unchanged
+  return url;
 }

--- a/source/image-handler/test/index.spec.ts
+++ b/source/image-handler/test/index.spec.ts
@@ -443,7 +443,7 @@ describe('handler', () => {
     // Cleanup the spying
     setupSpy.mockRestore();
   });
-  it('should not transform non External URLs and pass them to ImageRequest.setup', async () => {
+  it('should not transform External URLs and pass them to ImageRequest.setup', async () => {
     let event = {
       path: "/fit-in/500x500/filters:quality(70)/http://example.com/image.jpeg",
     };

--- a/source/image-handler/test/index.spec.ts
+++ b/source/image-handler/test/index.spec.ts
@@ -8,8 +8,6 @@ import { handler } from "../index";
 import { ImageHandlerError, ImageHandlerEvent, StatusCodes } from "../lib";
 import { ImageRequest } from "../image-request";
 
-
-
 describe("index", () => {
   // Arrange
   process.env.SOURCE_BUCKETS = "source-bucket";
@@ -422,8 +420,6 @@ describe("index", () => {
     });
     expect(result).toEqual(expectedResult);
   });
-
-  
 });
 
 describe('handler', () => {

--- a/source/image-handler/test/index.spec.ts
+++ b/source/image-handler/test/index.spec.ts
@@ -3,7 +3,7 @@
 
 import { mockAwsS3 } from "./mock";
 
-import { handler } from "../index";
+import { handler, transformCdnUrls } from "../index";
 import { ImageHandlerError, ImageHandlerEvent, StatusCodes } from "../lib";
 
 describe("index", () => {
@@ -417,5 +417,22 @@ describe("index", () => {
       Key: "test.jpg",
     });
     expect(result).toEqual(expectedResult);
+  });
+
+  describe('transformCdnUrls', () => {
+    it('transforms URL correctly when matches', () => {
+      const inputUrl = '/fit-in/500x500/filters:quality(70)/cdn-cgi/image/fit=contain,width=200,height=200/production/image.jpg';
+      const expectedUrl = '/fit-in/500x500/filters:quality(70)/production/image.jpg';
+      expect(transformCdnUrls(inputUrl)).toBe(expectedUrl);
+    });
+
+    it('leaves URL unchanged when it does not match pattern', () => {
+      const inputUrl = '/fit-in/500x500/filters:quality(70)/production/image.jpg';
+      expect(transformCdnUrls(inputUrl)).toBe(inputUrl);
+
+      const inputUrl2 = '/fit-in/500x500/filters:quality(70)/http://abc.com/image.jpg';
+      expect(transformCdnUrls(inputUrl2)).toBe(inputUrl2);
+
+    });
   });
 });

--- a/source/image-handler/test/index.spec.ts
+++ b/source/image-handler/test/index.spec.ts
@@ -481,4 +481,23 @@ describe('handler', () => {
     // Cleanup the spying
     setupSpy.mockRestore();
   });
+  it('handle generic urls too them to ImageRequest.setup', async () => {
+    let event = {
+      path: "/resize/filters:focal(70)/cdn-cgi/image/fit=contain,width=200,height=200/production/image.jpeg",
+    };
+
+    
+    const setupSpy = jest.spyOn(ImageRequest.prototype, 'setup');
+
+    await handler(event);
+
+    // check that setup has been called with the correctly transformed URL
+    expect(setupSpy).toHaveBeenCalledWith({
+      ...event,
+      path: "/resize/filters:focal(70)/production/image.jpeg"
+    });
+
+    // Cleanup the spying
+    setupSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
**Issue #, if available:**
<!-- If there're any related issues, please add the issue number here. -->
[GROWTH-1025](https://stocktwits.atlassian.net/browse/GROWTH-1025)


**Description of changes:**
<!-- Please describe the changes you made -->
Add check in SIH to handle URL   https://d1yvmrqyrgxzoj.cloudfront.net/fit-in/280x11/filters:quality(75)/cdn-cgi/image/fit=contain,width=175,height=98/01_Epizykloide-Kardioide-352x352.gif
and not give 404


**Checklist**
[new_tests_all_pass.txt](https://github.com/stocktwits/serverless-image-handler/files/11527038/new_tests_all_pass.txt)

- [x] :wave: I have added unit tests for all code changes.  
- [x] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


[GROWTH-1025]: https://stocktwits.atlassian.net/browse/GROWTH-1025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ