### PR TITLE
[BG][Growth 1027]: reduce url errors

### DIFF
--- a/source/image-handler/image-request.ts
+++ b/source/image-handler/image-request.ts
@@ -313,7 +313,7 @@ export class ImageRequest {
 
       return result;
     } catch (error) {
-      console.log("Siyanat",error)
+      console.log("Siyanat",JSON.stringify(error))
       let status = error.status;
       let message = error.message;
       if (error.code === "NoSuchKey") {

--- a/source/image-handler/image-request.ts
+++ b/source/image-handler/image-request.ts
@@ -313,7 +313,7 @@ export class ImageRequest {
 
       return result;
     } catch (error) {
-      let status = StatusCodes.INTERNAL_SERVER_ERROR;
+      let status = error.status;
       let message = error.message;
       if (error.code === "NoSuchKey") {
         status = StatusCodes.NOT_FOUND;

--- a/source/image-handler/image-request.ts
+++ b/source/image-handler/image-request.ts
@@ -235,6 +235,7 @@ export class ImageRequest {
     });
   
     const options: RequestInit = {
+      method: 'GET',
       headers: headers,
       redirect: 'manual',
     };

--- a/source/image-handler/image-request.ts
+++ b/source/image-handler/image-request.ts
@@ -313,7 +313,8 @@ export class ImageRequest {
 
       return result;
     } catch (error) {
-      let status = error.status;
+      console.log("Siyanat",error)
+      //let status = error.status;
       let message = error.message;
       if (error.code === "NoSuchKey") {
         status = StatusCodes.NOT_FOUND;

--- a/source/image-handler/image-request.ts
+++ b/source/image-handler/image-request.ts
@@ -314,7 +314,7 @@ export class ImageRequest {
       return result;
     } catch (error) {
       console.log("Siyanat",error)
-      //let status = error.status;
+      let status = error.status;
       let message = error.message;
       if (error.code === "NoSuchKey") {
         status = StatusCodes.NOT_FOUND;

--- a/source/image-handler/image-request.ts
+++ b/source/image-handler/image-request.ts
@@ -4,10 +4,7 @@
 import S3 from "aws-sdk/clients/s3";
 import { createHmac } from "crypto";
 import sharp, { Metadata } from "sharp";
-import fetch, { Headers as FetchHeaders, RequestInit } from 'node-fetch';
 import axios from 'axios';
-
-
 
 import {
   ContentTypes,
@@ -317,7 +314,6 @@ export class ImageRequest {
       return result;
     } catch (error) {
       let status = StatusCodes.INTERNAL_SERVER_ERROR;
-      //The following two is for external url
       if(error.message.includes('403')) {
         status = StatusCodes.FORBIDDEN
       }
@@ -325,7 +321,7 @@ export class ImageRequest {
         status = StatusCodes.NOT_FOUND
       }
       else if(error.message.includes('401')) {
-        status = StatusCodes.
+        status = StatusCodes.UNAUTHORIZED
       }
       let message = error.message;
       if (error.code === "NoSuchKey") {

--- a/source/image-handler/image-request.ts
+++ b/source/image-handler/image-request.ts
@@ -313,8 +313,10 @@ export class ImageRequest {
 
       return result;
     } catch (error) {
-      console.log("Siyanat",JSON.stringify(error))
-      let status = error.status;
+      let status = StatusCodes.INTERNAL_SERVER_ERROR;
+      if(error.message.includes('403')) {
+        status = StatusCodes.FORBIDDEN
+      }
       let message = error.message;
       if (error.code === "NoSuchKey") {
         status = StatusCodes.NOT_FOUND;

--- a/source/image-handler/image-request.ts
+++ b/source/image-handler/image-request.ts
@@ -37,6 +37,8 @@ const ALLOWED_CONTENT_TYPES = [
   'image/gif',
   'image/webp',
   'image/svg+xml',
+  'binary/octet-stream',
+  'application/octet-stream'
 ];
 const MAX_REDIRECTS = 3;
 
@@ -237,7 +239,6 @@ export class ImageRequest {
     const options: RequestInit = {
       method: 'GET',
       headers: headers,
-      redirect: 'manual',
     };
   
     const response = await fetch(url, options);

--- a/source/image-handler/lib/enums.ts
+++ b/source/image-handler/lib/enums.ts
@@ -7,6 +7,7 @@ export enum StatusCodes {
   FORBIDDEN = 403,
   NOT_FOUND = 404,
   REQUEST_TOO_LONG = 413,
+  UNAUTHORIZED = 401,
   INTERNAL_SERVER_ERROR = 500,
 }
 

--- a/source/image-handler/package.json
+++ b/source/image-handler/package.json
@@ -22,7 +22,8 @@
     "color": "4.2.3",
     "color-name": "1.1.4",
     "sharp": "^0.31.1",
-    "node-fetch": "^2.6.1"
+    "node-fetch": "^2.6.1",
+    "axios": "^1.4.0"
   },
   "devDependencies": {
     "@types/color": "^3.0.3",

--- a/source/image-handler/package.json
+++ b/source/image-handler/package.json
@@ -21,7 +21,8 @@
   "dependencies": {
     "color": "4.2.3",
     "color-name": "1.1.4",
-    "sharp": "^0.31.1"
+    "sharp": "^0.31.1",
+    "node-fetch": "^2.6.1"
   },
   "devDependencies": {
     "@types/color": "^3.0.3",

--- a/source/image-handler/package.json
+++ b/source/image-handler/package.json
@@ -22,7 +22,6 @@
     "color": "4.2.3",
     "color-name": "1.1.4",
     "sharp": "^0.31.1",
-    "node-fetch": "^2.6.1",
     "axios": "^1.4.0"
   },
   "devDependencies": {

--- a/source/image-handler/test/image-request/get-original-image.spec.ts
+++ b/source/image-handler/test/image-request/get-original-image.spec.ts
@@ -55,6 +55,18 @@ describe("getOriginalImage", () => {
     expect(result.originalImage).toBeInstanceOf(Buffer);
   });
 
+  it("Should pass for content tye application octet", async () => {
+    // Mock
+    // Act
+    const imageRequest = new ImageRequest(s3Client, secretProvider);
+    const result = await imageRequest.getOriginalImage("", "https://static.finnhub.io/logo/f47dde7da64ae0fc2df0d0f0ba75ab55aafa49c506a5b8ce1ca778c6a9a669d3.png")
+
+    // Assert
+    expect(result).toBeTruthy;
+    expect(result.originalImage).toBeInstanceOf(Buffer);
+  });
+
+
   it("Should throw an error if an invalid bucket or key name is provided, simulating a non-existent original image", async () => {
     // Mock
     mockAwsS3.getObject.mockImplementationOnce(() => ({

--- a/source/package.json
+++ b/source/package.json
@@ -2,7 +2,7 @@
   "name": "source",
   "version": "6.1.1",
   "private": true,
-  "st-version": "1.1.0",
+  "st-version": "1.2.0",
   "description": "ESLint and prettier dependencies to be used within the solution",
   "license": "Apache-2.0",
   "author": "AWS Solutions",


### PR DESCRIPTION
**Issue #, if available:**
<!-- If there're any related issues, please add the issue number here. -->
[GROWTH-1027](https://stocktwits.atlassian.net/browse/GROWTH-1027)


**Description of changes:**
<!-- Please describe the changes you made -->
Added a new library which reduces 500 errors for complicated image types 
Added handling for images with content type as application/octet
Added headers from curl to reduce 403 errors

Test results 
[all_pass.txt](https://github.com/stocktwits/serverless-image-handler/files/11744821/all_pass.txt)

**Checklist**
- [x] :wave: I have added unit tests for all code changes.
- [x] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.




[GROWTH-1027]: https://stocktwits.atlassian.net/browse/GROWTH-1027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ