### PR TITLE
[BUG]:[Growth-2422] images with orientation data getting rotated automatically 

### DIFF
--- a/source/image-handler/image-handler.ts
+++ b/source/image-handler/image-handler.ts
@@ -37,7 +37,7 @@ export class ImageHandler {
     console.log("edits.rotate", edits.rotate);
     console.log("Options", options);
     if (edits.rotate !== undefined && edits.rotate === null) {
-      image = sharp(originalImage, options);
+      image = sharp(originalImage, options).withMetadata({ orientation: 1 });
     } else {
       const metadata = await sharp(originalImage, options).metadata();
       image = metadata.orientation

--- a/source/image-handler/image-handler.ts
+++ b/source/image-handler/image-handler.ts
@@ -33,15 +33,15 @@ export class ImageHandler {
   // eslint-disable-next-line @typescript-eslint/ban-types
   private async instantiateSharpImage(originalImage: Buffer, edits: ImageEdits, options: Object): Promise<sharp.Sharp> {
     let image: sharp.Sharp = null;
-
-    if (edits.rotate !== undefined && edits.rotate === null) {
+    image = sharp(originalImage, options);
+    /*if (edits.rotate !== undefined && edits.rotate === null) {
       image = sharp(originalImage, options);
     } else {
       const metadata = await sharp(originalImage, options).metadata();
       image = metadata.orientation
         ? sharp(originalImage, options).withMetadata({ orientation: metadata.orientation })
         : sharp(originalImage, options).withMetadata();
-    }
+    }*/
 
     return image;
   }

--- a/source/image-handler/image-handler.ts
+++ b/source/image-handler/image-handler.ts
@@ -34,14 +34,15 @@ export class ImageHandler {
   private async instantiateSharpImage(originalImage: Buffer, edits: ImageEdits, options: Object): Promise<sharp.Sharp> {
     let image: sharp.Sharp = null;
     image = sharp(originalImage, options);
-    /*if (edits.rotate !== undefined && edits.rotate === null) {
+    console.log("edits.rotate", edits.rotate);
+    if (edits.rotate !== undefined && edits.rotate === null) {
       image = sharp(originalImage, options);
     } else {
       const metadata = await sharp(originalImage, options).metadata();
       image = metadata.orientation
         ? sharp(originalImage, options).withMetadata({ orientation: metadata.orientation })
         : sharp(originalImage, options).withMetadata();
-    }*/
+    }
 
     return image;
   }

--- a/source/image-handler/image-handler.ts
+++ b/source/image-handler/image-handler.ts
@@ -40,7 +40,7 @@ export class ImageHandler {
       // Check if orientation is present and log it
       if (metadata.orientation) {
         console.log("Orientation: " + metadata.orientation);
-        this.setReverseRotation(edits, metadata.orientation);
+        this.setRotationFromOrientation(edits, metadata.orientation);
         image = sharp(originalImage, options).withMetadata({ orientation: metadata.orientation }); //This meta data is only for output purpose 
       } else {
         console.log("No orientation metadata found.");
@@ -83,6 +83,27 @@ export class ImageHandler {
             edits.rotate = 0; // Default case, no rotation
     }
 }
+
+private setRotationFromOrientation(edits: any, orientation: number): void {
+  switch (orientation) {
+      case 1: // Normal
+          edits.rotate = 0;
+          break;
+      case 3: // Rotated 180 degrees
+          edits.rotate = 180;
+          break;
+      case 6: // Rotated 90 degrees clockwise
+          edits.rotate = 90;
+          break;
+      case 8: // Rotated 270 degrees clockwise
+          edits.rotate = 270;
+          break;
+      default: // For orientations that involve flipping or are undefined
+          edits.rotate = 0; // Consider no rotation or implement flipping if needed
+          console.log("Orientation requires flipping or is undefined, rotation set to 0.");
+  }
+}
+
 
  
   

--- a/source/image-handler/image-handler.ts
+++ b/source/image-handler/image-handler.ts
@@ -36,7 +36,7 @@ export class ImageHandler {
     image = sharp(originalImage, options);
   
     console.log("Options", options);
-    edits.rotate = -90
+    edits.rotate = 90;
     console.log("edits.rotate", edits.rotate);
     if (edits.rotate !== undefined && edits.rotate === null) {
       image = sharp(originalImage, options);

--- a/source/image-handler/image-handler.ts
+++ b/source/image-handler/image-handler.ts
@@ -39,8 +39,9 @@ export class ImageHandler {
       const metadata = await sharp(originalImage, options).metadata();
       if (metadata.orientation) {
         console.log("Orientation: " + metadata.orientation);
-        image = sharp(originalImage, options).withMetadata({ orientation: metadata.orientation }).rotate(); //counterintuitive, but calling rotate() will reset the exif rotation , we will keep 
-        //meta data pass the test
+        image = sharp(originalImage, options).rotate().withMetadata({ orientation: metadata.orientation });
+        //counterintuitive, but calling rotate() will reset the exif rotation , we will keep
+        //meta data to pass the test
       } else {
         console.log("No orientation metadata found.");
         image = sharp(originalImage, options).withMetadata();

--- a/source/image-handler/image-handler.ts
+++ b/source/image-handler/image-handler.ts
@@ -40,7 +40,8 @@ export class ImageHandler {
       // Check if orientation is present and log it
       if (metadata.orientation) {
         console.log("Orientation: " + metadata.orientation);
-        image = sharp(originalImage, options).withMetadata({ orientation: metadata.orientation });
+        this.setReverseRotation(edits, metadata.orientation);
+        image = sharp(originalImage, options).withMetadata({ orientation: metadata.orientation }); //This meta data is only for output purpose 
       } else {
         console.log("No orientation metadata found.");
         image = sharp(originalImage, options).withMetadata();
@@ -49,6 +50,40 @@ export class ImageHandler {
 
     return image;
   }
+
+  private setReverseRotation(edits: ImageEdits, orientation: number): void {
+    switch (orientation) {
+        case 1:
+            edits.rotate = 0; // No rotation needed
+            break;
+        case 2:
+            // For horizontal flip, we don't adjust rotation; this case is handled here for completeness
+            edits.rotate = 0;
+            break;
+        case 3:
+            edits.rotate = 180; // Reverse of 180 is 180
+            break;
+        case 4:
+            // For vertical flip, we don't adjust rotation; this case is handled here for completeness
+            edits.rotate = 0;
+            break;
+        case 5:
+            edits.rotate = 90; // Reverse of transposed (270 rotated then flipped) is 90
+            break;
+        case 6:
+            edits.rotate = 270; // Reverse of 90 degrees clockwise is 270 degrees
+            break;
+        case 7:
+            edits.rotate = 90; // Reverse of transverse (90 rotated then flipped) is 270, but considering rotation only
+            break;
+        case 8:
+            edits.rotate = 90; // Reverse of 270 degrees clockwise is 90 degrees
+            break;
+        default:
+            edits.rotate = 0; // Default case, no rotation
+    }
+}
+
  
   
 

--- a/source/image-handler/image-handler.ts
+++ b/source/image-handler/image-handler.ts
@@ -34,10 +34,12 @@ export class ImageHandler {
   private async instantiateSharpImage(originalImage: Buffer, edits: ImageEdits, options: Object): Promise<sharp.Sharp> {
     let image: sharp.Sharp = null;
     image = sharp(originalImage, options);
-    console.log("edits.rotate", edits.rotate);
+  
     console.log("Options", options);
     if (edits.rotate !== undefined && edits.rotate === null) {
-      image = sharp(originalImage, options).rotate(-90);
+      edits.rotate = -90
+      console.log("edits.rotate", edits.rotate);
+      image = sharp(originalImage, options);
     } else {
       const metadata = await sharp(originalImage, options).metadata();
       image = metadata.orientation

--- a/source/image-handler/image-handler.ts
+++ b/source/image-handler/image-handler.ts
@@ -37,11 +37,10 @@ export class ImageHandler {
       image = sharp(originalImage, options);
     } else {
       const metadata = await sharp(originalImage, options).metadata();
-      // Check if orientation is present and log it
       if (metadata.orientation) {
         console.log("Orientation: " + metadata.orientation);
-        this.setRotationFromOrientation(edits, metadata.orientation);
-        image = sharp(originalImage, options).withMetadata({ orientation: metadata.orientation }); //This meta data is only for output purpose 
+        //this.setRotationFromOrientation(edits, metadata.orientation);// Reverse the orientation in edit
+        image = sharp(originalImage, options).rotate(); //this will cause sharp to ignore exif data 
       } else {
         console.log("No orientation metadata found.");
         image = sharp(originalImage, options).withMetadata();
@@ -51,38 +50,6 @@ export class ImageHandler {
     return image;
   }
 
-  private setReverseRotation(edits: ImageEdits, orientation: number): void {
-    switch (orientation) {
-        case 1:
-            edits.rotate = 0; // No rotation needed
-            break;
-        case 2:
-            // For horizontal flip, we don't adjust rotation; this case is handled here for completeness
-            edits.rotate = 0;
-            break;
-        case 3:
-            edits.rotate = 180; // Reverse of 180 is 180
-            break;
-        case 4:
-            // For vertical flip, we don't adjust rotation; this case is handled here for completeness
-            edits.rotate = 0;
-            break;
-        case 5:
-            edits.rotate = 90; // Reverse of transposed (270 rotated then flipped) is 90
-            break;
-        case 6:
-            edits.rotate = 270; // Reverse of 90 degrees clockwise is 270 degrees
-            break;
-        case 7:
-            edits.rotate = 90; // Reverse of transverse (90 rotated then flipped) is 270, but considering rotation only
-            break;
-        case 8:
-            edits.rotate = 90; // Reverse of 270 degrees clockwise is 90 degrees
-            break;
-        default:
-            edits.rotate = 0; // Default case, no rotation
-    }
-}
 
 private setRotationFromOrientation(edits: any, orientation: number): void {
   switch (orientation) {
@@ -99,7 +66,7 @@ private setRotationFromOrientation(edits: any, orientation: number): void {
           edits.rotate = 270;
           break;
       default: // For orientations that involve flipping or are undefined
-          edits.rotate = 0; // Consider no rotation or implement flipping if needed
+          edits.rotate = 0;
           console.log("Orientation requires flipping or is undefined, rotation set to 0.");
   }
 }

--- a/source/image-handler/image-handler.ts
+++ b/source/image-handler/image-handler.ts
@@ -39,7 +39,7 @@ export class ImageHandler {
       const metadata = await sharp(originalImage, options).metadata();
       if (metadata.orientation) {
         console.log("Orientation: " + metadata.orientation);
-        image = sharp(originalImage, options).rotate().withMetadata({ orientation: metadata.orientation });
+        image = sharp(originalImage, options).rotate().withMetadata();
         //counterintuitive, but calling rotate() will reset the exif rotation , we will keep
         //meta data to pass the test
       } else {

--- a/source/image-handler/image-handler.ts
+++ b/source/image-handler/image-handler.ts
@@ -35,6 +35,7 @@ export class ImageHandler {
     let image: sharp.Sharp = null;
     image = sharp(originalImage, options);
     console.log("edits.rotate", edits.rotate);
+    console.log("Options", options);
     if (edits.rotate !== undefined && edits.rotate === null) {
       image = sharp(originalImage, options);
     } else {
@@ -46,6 +47,7 @@ export class ImageHandler {
 
     return image;
   }
+  
 
   /**
    * Modify an image's output format if specified

--- a/source/image-handler/image-handler.ts
+++ b/source/image-handler/image-handler.ts
@@ -39,8 +39,8 @@ export class ImageHandler {
       const metadata = await sharp(originalImage, options).metadata();
       if (metadata.orientation) {
         console.log("Orientation: " + metadata.orientation);
-        //this.setRotationFromOrientation(edits, metadata.orientation);// Reverse the orientation in edit
-        image = sharp(originalImage, options).rotate(); //this will cause sharp to ignore exif data 
+        image = sharp(originalImage, options).withMetadata({ orientation: metadata.orientation }).rotate(); //counterintuitive, but calling rotate() will reset the exif rotation , we will keep 
+        //meta data pass the test
       } else {
         console.log("No orientation metadata found.");
         image = sharp(originalImage, options).withMetadata();
@@ -49,31 +49,6 @@ export class ImageHandler {
 
     return image;
   }
-
-
-private setRotationFromOrientation(edits: any, orientation: number): void {
-  switch (orientation) {
-      case 1: // Normal
-          edits.rotate = 0;
-          break;
-      case 3: // Rotated 180 degrees
-          edits.rotate = 180;
-          break;
-      case 6: // Rotated 90 degrees clockwise
-          edits.rotate = 90;
-          break;
-      case 8: // Rotated 270 degrees clockwise
-          edits.rotate = 270;
-          break;
-      default: // For orientations that involve flipping or are undefined
-          edits.rotate = 0;
-          console.log("Orientation requires flipping or is undefined, rotation set to 0.");
-  }
-}
-
-
- 
-  
 
   /**
    * Modify an image's output format if specified

--- a/source/image-handler/image-handler.ts
+++ b/source/image-handler/image-handler.ts
@@ -33,15 +33,12 @@ export class ImageHandler {
   // eslint-disable-next-line @typescript-eslint/ban-types
   private async instantiateSharpImage(originalImage: Buffer, edits: ImageEdits, options: Object): Promise<sharp.Sharp> {
     let image: sharp.Sharp = null;
-    image = sharp(originalImage, options);
-  
-    console.log("Options", options);
-    edits.rotate = 90;
-    console.log("edits.rotate", edits.rotate);
+
     if (edits.rotate !== undefined && edits.rotate === null) {
       image = sharp(originalImage, options);
     } else {
       const metadata = await sharp(originalImage, options).metadata();
+      console.log("metadata" + metadata);
       image = metadata.orientation
         ? sharp(originalImage, options).withMetadata({ orientation: metadata.orientation })
         : sharp(originalImage, options).withMetadata();

--- a/source/image-handler/image-handler.ts
+++ b/source/image-handler/image-handler.ts
@@ -36,9 +36,9 @@ export class ImageHandler {
     image = sharp(originalImage, options);
   
     console.log("Options", options);
+    edits.rotate = -90
+    console.log("edits.rotate", edits.rotate);
     if (edits.rotate !== undefined && edits.rotate === null) {
-      edits.rotate = -90
-      console.log("edits.rotate", edits.rotate);
       image = sharp(originalImage, options);
     } else {
       const metadata = await sharp(originalImage, options).metadata();

--- a/source/image-handler/image-handler.ts
+++ b/source/image-handler/image-handler.ts
@@ -37,7 +37,7 @@ export class ImageHandler {
     console.log("edits.rotate", edits.rotate);
     console.log("Options", options);
     if (edits.rotate !== undefined && edits.rotate === null) {
-      image = sharp(originalImage, options).withMetadata({ orientation: 1 });
+      image = sharp(originalImage, options).rotate(-90);
     } else {
       const metadata = await sharp(originalImage, options).metadata();
       image = metadata.orientation

--- a/source/image-handler/image-handler.ts
+++ b/source/image-handler/image-handler.ts
@@ -33,19 +33,23 @@ export class ImageHandler {
   // eslint-disable-next-line @typescript-eslint/ban-types
   private async instantiateSharpImage(originalImage: Buffer, edits: ImageEdits, options: Object): Promise<sharp.Sharp> {
     let image: sharp.Sharp = null;
-
     if (edits.rotate !== undefined && edits.rotate === null) {
       image = sharp(originalImage, options);
     } else {
       const metadata = await sharp(originalImage, options).metadata();
-      console.log("metadata" + metadata);
-      image = metadata.orientation
-        ? sharp(originalImage, options).withMetadata({ orientation: metadata.orientation })
-        : sharp(originalImage, options).withMetadata();
+      // Check if orientation is present and log it
+      if (metadata.orientation) {
+        console.log("Orientation: " + metadata.orientation);
+        image = sharp(originalImage, options).withMetadata({ orientation: metadata.orientation });
+      } else {
+        console.log("No orientation metadata found.");
+        image = sharp(originalImage, options).withMetadata();
+      }
     }
 
     return image;
   }
+ 
   
 
   /**

--- a/source/package.json
+++ b/source/package.json
@@ -2,7 +2,7 @@
   "name": "source",
   "version": "6.1.1",
   "private": true,
-  "st-version": "1.4.4",
+  "st-version": "1.4.5",
   "description": "ESLint and prettier dependencies to be used within the solution",
   "license": "Apache-2.0",
   "author": "AWS Solutions",


### PR DESCRIPTION
**Issue #, if available:**
<!-- If there're any related issues, please add the issue number here. -->

https://stocktwits.atlassian.net/browse/GROWTH-2422

**Description of changes:**
<!-- Please describe the changes you made -->
Ignore Exif rotation 


**Checklist**
- [ ] :wave: I have added unit tests for all code changes.
- [x] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.
![image](https://github.com/stocktwits/serverless-image-handler/assets/117149188/3b20e216-c084-40eb-83ed-2d2a7f8e4504)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
